### PR TITLE
Publish camera_info rostopic

### DIFF
--- a/src/plugin/BodyROSItem.h
+++ b/src/plugin/BodyROSItem.h
@@ -99,7 +99,7 @@ private:
     std::vector<ros::Publisher> forceSensorPublishers;
     std::vector<ros::Publisher> rateGyroSensorPublishers;
     std::vector<ros::Publisher> accelSensorPublishers;
-    std::vector<image_transport::Publisher> visionSensorPublishers;
+    std::vector<image_transport::CameraPublisher> visionSensorPublishers;
     std::vector<ros::Publisher> rangeVisionSensorPublishers;
     std::vector<ros::Publisher> rangeSensorPublishers;
     std::vector<ros::Publisher> rangeSensorPcPublishers;
@@ -119,7 +119,7 @@ private:
     void updateAccelSensor(
         const AccelerationSensorPtr& sensor, const ros::Publisher& publisher);
     void updateVisionSensor(
-        const CameraPtr& sensor, const image_transport::Publisher& publisher);
+        const CameraPtr& sensor, const image_transport::CameraPublisher& publisher);
     void updateRangeVisionSensor(
         const RangeCameraPtr& sensor, const ros::Publisher& publisher);
     void updateRangeSensor(


### PR DESCRIPTION
Changed from image_transport::Publisher to image_transport::CameraPublisher

This way when choreonoid publishes the images from a camera to a rostopic, the rostopic /camera/camera_info is created
The intrinsic model of the camera is computed from the sensor values